### PR TITLE
Fix imask preserve value on mask change

### DIFF
--- a/app/components/Inputs/functions/useInputUtils.ts
+++ b/app/components/Inputs/functions/useInputUtils.ts
@@ -50,9 +50,7 @@ export function useInputUtils(options: IInputUtilsOptions) {
   const { el, mask, masked, unmasked, typed } = useIMask(maskRef, {
     onAccept: ev => {
       nextTick(() => {
-        const isMaskChanging = isMaskRefChanging.value
-
-        if (isMaskChanging) {
+        if (isMaskRefChanging.value) {
           typed.value = preservedValue.value
           lastValidValue.value = preservedValue.value
 

--- a/app/components/Inputs/functions/useInputUtils.ts
+++ b/app/components/Inputs/functions/useInputUtils.ts
@@ -38,11 +38,27 @@ export function useInputUtils(options: IInputUtilsOptions) {
 
   // Mask
   const lastValidValue = ref<any>()
+  const isMaskRefChanging = shallowRef(false)
+  const preservedValue = shallowRef<any>()
   const { emptyValue } = toRefs(props)
+
+  function clearMaskChange() {
+    isMaskRefChanging.value = false
+    preservedValue.value = undefined
+  }
 
   const { el, mask, masked, unmasked, typed } = useIMask(maskRef, {
     onAccept: ev => {
       nextTick(() => {
+        const isMaskChanging = isMaskRefChanging.value
+
+        if (isMaskChanging) {
+          typed.value = preservedValue.value
+          lastValidValue.value = preservedValue.value
+
+          return
+        }
+
         const val = maskEventHandlers?.onAccept?.(
           lastValidValue.value,
           ev,
@@ -63,6 +79,24 @@ export function useInputUtils(options: IInputUtilsOptions) {
 
   const originalModel = useVModel(props, 'modelValue', undefined, { defaultValue: props.emptyValue })
   const model = ref(originalModel.value)
+
+  const {
+    start: startMaskChangeTimeout,
+    stop: stopMaskChangeTimeout,
+  } = useTimeoutFn(() => {
+    if (!isMaskRefChanging.value) {
+      return
+    }
+
+    const currentVal = model.value
+
+    if (!isEqual(currentVal, preservedValue.value)) {
+      typed.value = currentVal
+      lastValidValue.value = currentVal
+    }
+
+    clearMaskChange()
+  }, 0, { immediate: false })
 
   // We also need to create an instance of mask to get the `masked` value
   // because `useIMask` initializes values in `onMounted` which would break SSR
@@ -311,6 +345,20 @@ export function useInputUtils(options: IInputUtilsOptions) {
       }
     }
   })
+
+  // When changing the mask, we need to preserve the value
+  watch(maskRef, () => {
+    stopMaskChangeTimeout()
+
+    const val = model.value
+
+    isMaskRefChanging.value = true
+    preservedValue.value = val
+    lastValidValue.value = val
+
+    // `nextTick` is not enough here, because the `maskRef` is changed in the same tick
+    startMaskChangeTimeout()
+  }, { flush: 'sync' })
 
   // We also need to sync the `model` when the `originalModel` changes
   watch(originalModel, val => {

--- a/app/components/Inputs/functions/useInputUtils.ts
+++ b/app/components/Inputs/functions/useInputUtils.ts
@@ -77,11 +77,18 @@ export function useInputUtils(options: IInputUtilsOptions) {
 
   const originalModel = useVModel(props, 'modelValue', undefined, { defaultValue: props.emptyValue })
   const model = ref(originalModel.value)
+  const maskFrame = shallowRef<number>()
 
-  const {
-    start: startMaskChangeTimeout,
-    stop: stopMaskChangeTimeout,
-  } = useTimeoutFn(() => {
+  function cancelMaskChangeFrame() {
+    if (isNil(maskFrame.value)) {
+      return
+    }
+
+    cancelAnimationFrame(maskFrame.value)
+    maskFrame.value = undefined
+  }
+
+  function completeMaskChangeFrame() { 
     if (!isMaskRefChanging.value) {
       return
     }
@@ -94,7 +101,16 @@ export function useInputUtils(options: IInputUtilsOptions) {
     }
 
     clearMaskChange()
-  }, 0, { immediate: false })
+  }
+
+  function requestMaskChangeFrame() {
+    cancelMaskChangeFrame()
+
+    maskFrame.value = requestAnimationFrame(() => {
+      maskFrame.value = undefined
+      completeMaskChangeFrame()
+    })
+  }
 
   // We also need to create an instance of mask to get the `masked` value
   // because `useIMask` initializes values in `onMounted` which would break SSR
@@ -346,16 +362,12 @@ export function useInputUtils(options: IInputUtilsOptions) {
 
   // When changing the mask, we need to preserve the value
   watch(maskRef, () => {
-    stopMaskChangeTimeout()
-
-    const val = model.value
-
     isMaskRefChanging.value = true
-    preservedValue.value = val
-    lastValidValue.value = val
+    preservedValue.value = model.value
+    lastValidValue.value = model.value
 
     // `nextTick` is not enough here, because the `maskRef` is changed in the same tick
-    startMaskChangeTimeout()
+    requestMaskChangeFrame()
   }, { flush: 'sync' })
 
   // We also need to sync the `model` when the `originalModel` changes
@@ -370,6 +382,9 @@ export function useInputUtils(options: IInputUtilsOptions) {
       lastValidValue.value = model.value
     })
   })
+
+  // Cleanup
+  onBeforeUnmount(cancelMaskChangeFrame)
 
   provide('inputId', inputId)
 


### PR DESCRIPTION
This DateInput change depends on this fix: https://github.com/gentlsro/utilities/pull/8 (workaround is use directly currentLocaleCode..) 

We watch the mask so `DateInput` can distinguish a locale mask change from real user input

```ts
DD. MM. YYYY -> MM/DD/YYYY
```