### PR TITLE
(Table) Add onSelectAll callback to selectionConfig

### DIFF
--- a/client/components/Table/TableHeader/TableHeaderCell.vue
+++ b/client/components/Table/TableHeader/TableHeaderCell.vue
@@ -91,26 +91,29 @@ const selectionState = computed(() => {
 })
 
 function handleSelect() {
-  // Some selected
+  // Some rows selected (indeterminate) → select all
   if (selectionState.value === null) {
     const toSelect = rowKeys.value.map((rowKey, idx) => {
       return selectionConfig.value?.emitKey ? rowKey : rows.value[idx]
     })
 
+    selectionConfig.value?.onSelectAll?.(toSelect)
     selection.value = toSelect
   }
 
-  // All selected
+  // All rows selected → deselect all
   else if (selectionState.value === true) {
-    selection.value = selectionConfig.value.multi ? [] : undefined
+    selectionConfig.value?.onSelectAll?.([])
+    selection.value = selectionConfig.value?.multi ? [] : undefined
   }
 
-  // Not all selected
+  // No rows selected → select all
   else {
     const toSelect = rowKeys.value.map((rowKey, idx) => {
       return selectionConfig.value?.emitKey ? rowKey : rows.value[idx]
     })
 
+    selectionConfig.value?.onSelectAll?.(toSelect)
     selection.value = toSelect
   }
 }

--- a/client/components/Table/types/table-props.type.ts
+++ b/client/components/Table/types/table-props.type.ts
@@ -521,6 +521,13 @@ export type ITableProps<
     disabled?: ((row: any) => boolean)
 
     /**
+     * Function that gets called when all rows are selected/deselected via the
+     * header checkbox. Receives the rows being selected, or an empty array when
+     * deselecting all.
+     */
+    onSelectAll?: (rows: any[]) => void
+
+    /**
      * Whether the selection is multi-select
      */
     multi?: boolean


### PR DESCRIPTION
 The header checkbox (select all / deselect all) was directly mutating
  `selection` without calling `onSelect`, leaving consumers with no way
  to react to bulk selection changes.

  Added `onSelectAll` to `selectionConfig` and wired it into
  `TableHeaderCell.handleSelect` for all three selection states
  (none → all, some → all, all → none).